### PR TITLE
Prepare 1.0.1 release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*           text=auto
+*.sh        text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ venv.bak/
 
 deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml
 deployment/kubernetes-manifests/quickstart-k8s/yamls/secret.yaml
+deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ ENV/
 env.bak/
 venv.bak/
 
+deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml
+deployment/kubernetes-manifests/quickstart-k8s/yamls/secret.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.vscode
 *.dat
 *.original
 *.lst

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,7 @@ DeployArgs=""
 
 # build image
 .PHONY: build
-build: clean-image package build-image
-
-.PHONY: package
-package:
-	@mvn clean package -Dmaven.test.skip=true
+build: clean-image build-image
 
 .PHONY: build-image
 build-image:

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,18 @@ push-image:
 publish-image:
 	@script/publish-docker-images.sh $(Repo) $(Tag)
 
+# deploy from source
+.PHONY: deploy
+deploy: build deploy-no-build
+
 # deploy
 # DeployArgs ""                    : deploy train-ticket with all-in-one mysql cluster
 # DeployArgs "--independent-db"    : deploy train-ticket with mysql cluster each service
 # DeployArgs "--with-monitoring"   : deploy train-ticket with prometheus
 # DeployArgs "--with-tracing"      : deploy train-ticket with skywalking
 # DeployArgs "--all"               : deploy train-ticket with mysql cluster each service
-.PHONY: deploy
-deploy:
+.PHONY: deploy-no-build
+deploy-no-build:
 	@hack/deploy/deploy.sh $(Namespace) "$(DeployArgs)"
 
 # deploy

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Codewisdom Train-Ticket system
 
 Repo=codewisdom
-Tag=latest
+Tag=1.0.1
 Namespace="default"
 DeployArgs=""
 

--- a/deployment/kubernetes-manifests/quickstart-k8s/charts/mysql/Chart.yaml
+++ b/deployment/kubernetes-manifests/quickstart-k8s/charts/mysql/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/deploy.yaml.sample
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: ts-admin-basic-info-service
-          image: codewisdom/ts-admin-basic-info-service:1.0.0
+          image: codewisdom/ts-admin-basic-info-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: ts-admin-route-service
-          image: codewisdom/ts-admin-route-service:1.0.0
+          image: codewisdom/ts-admin-route-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -140,7 +140,7 @@ spec:
     spec:
       containers:
         - name: ts-admin-travel-service
-          image: codewisdom/ts-admin-travel-service:1.0.0
+          image: codewisdom/ts-admin-travel-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -224,7 +224,7 @@ spec:
     spec:
       containers:
         - name: ts-assurance-service
-          image: codewisdom/ts-assurance-service:1.0.0
+          image: codewisdom/ts-assurance-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -268,7 +268,7 @@ spec:
     spec:
       containers:
         - name: ts-auth-service
-          image: codewisdom/ts-auth-service:1.0.0
+          image: codewisdom/ts-auth-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -354,7 +354,7 @@ spec:
     spec:
       containers:
         - name: ts-basic-service
-          image: codewisdom/ts-basic-service:1.0.0
+          image: codewisdom/ts-basic-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: codewisdom/ts-cancel-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -438,7 +438,7 @@ spec:
     spec:
       containers:
         - name: ts-config-service
-          image: codewisdom/ts-config-service:1.0.0
+          image: codewisdom/ts-config-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -482,7 +482,7 @@ spec:
     spec:
       containers:
         - name: ts-consign-price-service
-          image: codewisdom/ts-consign-price-service:1.0.0
+          image: codewisdom/ts-consign-price-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -570,7 +570,7 @@ spec:
     spec:
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: codewisdom/ts-contacts-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -614,7 +614,7 @@ spec:
     spec:
       containers:
         - name: ts-delivery-service
-          image: codewisdom/ts-delivery-service:1.0.0
+          image: codewisdom/ts-delivery-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -660,7 +660,7 @@ spec:
     spec:
       containers:
         - name: ts-execute-service
-          image: codewisdom/ts-execute-service:1.0.0
+          image: codewisdom/ts-execute-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -702,7 +702,7 @@ spec:
     spec:
       containers:
         - name: ts-food-service
-          image: codewisdom/ts-food-service:1.0.0
+          image: codewisdom/ts-food-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -748,7 +748,7 @@ spec:
     spec:
       containers:
         - name: ts-food-delivery-service
-          image: codewisdom/ts-food-delivery-service:1.0.0
+          image: codewisdom/ts-food-delivery-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -792,7 +792,7 @@ spec:
     spec:
       containers:
         - name: ts-gateway-service
-          image: codewisdom/ts-gateway-service:1.0.0
+          image: codewisdom/ts-gateway-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -834,7 +834,7 @@ spec:
     spec:
       containers:
         - name: ts-inside-payment-service
-          image: codewisdom/ts-inside-payment-service:1.0.0
+          image: codewisdom/ts-inside-payment-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -878,7 +878,7 @@ spec:
     spec:
       containers:
         - name: ts-news-service
-          image: codewisdom/ts-news-service:1.0.0
+          image: codewisdom/ts-news-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -920,7 +920,7 @@ spec:
     spec:
       containers:
         - name: ts-notification-service
-          image: codewisdom/ts-notification-service:1.0.0
+          image: codewisdom/ts-notification-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1058,7 +1058,7 @@ spec:
     spec:
       containers:
         - name: ts-payment-service
-          image: codewisdom/ts-payment-service:1.0.0
+          image: codewisdom/ts-payment-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1102,7 +1102,7 @@ spec:
     spec:
       containers:
         - name: ts-preserve-other-service
-          image: codewisdom/ts-preserve-other-service:1.0.0
+          image: codewisdom/ts-preserve-other-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1146,7 +1146,7 @@ spec:
     spec:
       containers:
         - name: ts-preserve-service
-          image: codewisdom/ts-preserve-service:1.0.0
+          image: codewisdom/ts-preserve-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1190,7 +1190,7 @@ spec:
     spec:
       containers:
         - name: ts-price-service
-          image: codewisdom/ts-price-service:1.0.0
+          image: codewisdom/ts-price-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1278,7 +1278,7 @@ spec:
     spec:
       containers:
         - name: ts-route-plan-service
-          image: codewisdom/ts-route-plan-service:1.0.0
+          image: codewisdom/ts-route-plan-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1320,7 +1320,7 @@ spec:
     spec:
       containers:
         - name: ts-route-service
-          image: codewisdom/ts-route-service:1.0.0
+          image: codewisdom/ts-route-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1364,7 +1364,7 @@ spec:
     spec:
       containers:
         - name: ts-seat-service
-          image: codewisdom/ts-seat-service:1.0.0
+          image: codewisdom/ts-seat-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1406,7 +1406,7 @@ spec:
     spec:
       containers:
         - name: ts-security-service
-          image: codewisdom/ts-security-service:1.0.0
+          image: codewisdom/ts-security-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1450,7 +1450,7 @@ spec:
     spec:
       containers:
         - name: ts-station-food-service
-          image: codewisdom/ts-station-food-service:1.0.0
+          image: codewisdom/ts-station-food-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1538,7 +1538,7 @@ spec:
     spec:
       containers:
         - name: ts-ticket-office-service
-          image: codewisdom/ts-ticket-office-service:1.0.0
+          image: codewisdom/ts-ticket-office-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1582,7 +1582,7 @@ spec:
     spec:
       containers:
         - name: ts-train-food-service
-          image: codewisdom/ts-train-food-service:1.0.0
+          image: codewisdom/ts-train-food-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1626,7 +1626,7 @@ spec:
     spec:
       containers:
         - name: ts-train-service
-          image: codewisdom/ts-train-service:1.0.0
+          image: codewisdom/ts-train-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1670,7 +1670,7 @@ spec:
     spec:
       containers:
         - name: ts-travel-plan-service
-          image: codewisdom/ts-travel-plan-service:1.0.0
+          image: codewisdom/ts-travel-plan-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1712,7 +1712,7 @@ spec:
     spec:
       containers:
         - name: ts-travel-service
-          image: codewisdom/ts-travel-service:1.0.0
+          image: codewisdom/ts-travel-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1756,7 +1756,7 @@ spec:
     spec:
       containers:
         - name: ts-travel2-service
-          image: codewisdom/ts-travel2-service:1.0.0
+          image: codewisdom/ts-travel2-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1844,7 +1844,7 @@ spec:
     spec:
       containers:
         - name: ts-verification-code-service
-          image: codewisdom/ts-verification-code-service:1.0.0
+          image: codewisdom/ts-verification-code-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP
@@ -1886,7 +1886,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: codewisdom/ts-voucher-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
+++ b/deployment/kubernetes-manifests/quickstart-k8s/yamls/sw_deploy.yaml.sample
@@ -25,7 +25,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-admin-basic-info-service
-          image: codewisdom/ts-admin-basic-info-service:1.0.0
+          image: codewisdom/ts-admin-basic-info-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -161,7 +161,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-admin-route-service
-          image: codewisdom/ts-admin-route-service:1.0.0
+          image: codewisdom/ts-admin-route-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -229,7 +229,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-admin-travel-service
-          image: codewisdom/ts-admin-travel-service:1.0.0
+          image: codewisdom/ts-admin-travel-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -365,7 +365,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-assurance-service
-          image: codewisdom/ts-assurance-service:1.0.0
+          image: codewisdom/ts-assurance-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -435,7 +435,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-auth-service
-          image: codewisdom/ts-auth-service:1.0.0
+          image: codewisdom/ts-auth-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -573,7 +573,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-basic-service
-          image: codewisdom/ts-basic-service:1.0.0
+          image: codewisdom/ts-basic-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -641,7 +641,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-cancel-service
-          image: codewisdom/ts-cancel-service:1.0.0
+          image: codewisdom/ts-cancel-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -709,7 +709,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-config-service
-          image: codewisdom/ts-config-service:1.0.0
+          image: codewisdom/ts-config-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -779,7 +779,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-consign-price-service
-          image: codewisdom/ts-consign-price-service:1.0.0
+          image: codewisdom/ts-consign-price-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -919,7 +919,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-contacts-service
-          image: codewisdom/ts-contacts-service:1.0.0
+          image: codewisdom/ts-contacts-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -989,7 +989,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-delivery-service
-          image: codewisdom/ts-delivery-service:1.0.0
+          image: codewisdom/ts-delivery-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1061,7 +1061,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-execute-service
-          image: codewisdom/ts-execute-service:1.0.0
+          image: codewisdom/ts-execute-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1129,7 +1129,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-food-delivery-service
-          image: codewisdom/ts-food-delivery-service:1.0.0
+          image: codewisdom/ts-food-delivery-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1199,7 +1199,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-food-service
-          image: codewisdom/ts-food-service:1.0.0
+          image: codewisdom/ts-food-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1271,7 +1271,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-gateway-service
-          image: codewisdom/ts-gateway-service:1.0.0
+          image: codewisdom/ts-gateway-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1339,7 +1339,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-inside-payment-service
-          image: codewisdom/ts-inside-payment-service:1.0.0
+          image: codewisdom/ts-inside-payment-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1409,7 +1409,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-news-service
-          image: codewisdom/ts-news-service:1.0.0
+          image: codewisdom/ts-news-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1477,7 +1477,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-notification-service
-          image: codewisdom/ts-notification-service:1.0.0
+          image: codewisdom/ts-notification-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1693,7 +1693,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-payment-service
-          image: codewisdom/ts-payment-service:1.0.0
+          image: codewisdom/ts-payment-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1763,7 +1763,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-preserve-other-service
-          image: codewisdom/ts-preserve-other-service:1.0.0
+          image: codewisdom/ts-preserve-other-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1833,7 +1833,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-preserve-service
-          image: codewisdom/ts-preserve-service:1.0.0
+          image: codewisdom/ts-preserve-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -1903,7 +1903,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-price-service
-          image: codewisdom/ts-price-service:1.0.0
+          image: codewisdom/ts-price-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2043,7 +2043,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-route-plan-service
-          image: codewisdom/ts-route-plan-service:1.0.0
+          image: codewisdom/ts-route-plan-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2111,7 +2111,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-route-service
-          image: codewisdom/ts-route-service:1.0.0
+          image: codewisdom/ts-route-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2181,7 +2181,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-seat-service
-          image: codewisdom/ts-seat-service:1.0.0
+          image: codewisdom/ts-seat-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2249,7 +2249,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-security-service
-          image: codewisdom/ts-security-service:1.0.0
+          image: codewisdom/ts-security-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2319,7 +2319,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-station-food-service
-          image: codewisdom/ts-station-food-service:1.0.0
+          image: codewisdom/ts-station-food-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2459,7 +2459,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-ticket-office-service
-          image: codewisdom/ts-ticket-office-service:1.0.0
+          image: codewisdom/ts-ticket-office-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2529,7 +2529,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-train-food-service
-          image: codewisdom/ts-train-food-service:1.0.0
+          image: codewisdom/ts-train-food-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2599,7 +2599,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-train-service
-          image: codewisdom/ts-train-service:1.0.0
+          image: codewisdom/ts-train-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2669,7 +2669,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-travel-plan-service
-          image: codewisdom/ts-travel-plan-service:1.0.0
+          image: codewisdom/ts-travel-plan-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2737,7 +2737,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-travel-service
-          image: codewisdom/ts-travel-service:1.0.0
+          image: codewisdom/ts-travel-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2807,7 +2807,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-travel2-service
-          image: codewisdom/ts-travel2-service:1.0.0
+          image: codewisdom/ts-travel2-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -2947,7 +2947,7 @@ spec:
           args: [ "-c", "cp -R /skywalking/agent /agent/" ]
       containers:
         - name: ts-verification-code-service
-          image: codewisdom/ts-verification-code-service:1.0.0
+          image: codewisdom/ts-verification-code-service:1.0.1
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: skywalking-agent
@@ -3004,7 +3004,7 @@ spec:
     spec:
       containers:
         - name: ts-voucher-service
-          image: codewisdom/ts-voucher-service:1.0.0
+          image: codewisdom/ts-voucher-service:1.0.1
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_IP

--- a/deployment/kubernetes-manifests/skywalking/es.yml
+++ b/deployment/kubernetes-manifests/skywalking/es.yml
@@ -4,11 +4,13 @@ metadata:
   creationTimestamp: null
   name: elasticsearch
 spec:
+  type: NodePort
   ports:
   - name: db
     port: 9200
     protocol: TCP
     targetPort: 9200
+    nodePort: 30092
   - name: transport
     port: 9300
     protocol: TCP

--- a/hack/build-image.sh
+++ b/hack/build-image.sh
@@ -8,7 +8,7 @@ for dir in ts-*; do
     if [[ -d $dir ]]; then
         if [[ -n $(ls "$dir" | grep -i Dockerfile) ]]; then
             echo "build ${dir}"
-            docker build -t "$1"/"${dir}" "$dir"
+            docker build -t "$1"/"${dir}" -f "${dir}/Dockerfile" "."
             docker tag "$1"/"${dir}":latest "$1"/"${dir}":"$2"
         fi
     fi

--- a/script/publish-docker-images.sh
+++ b/script/publish-docker-images.sh
@@ -9,7 +9,7 @@ for dir in ts-*; do
         if [[ -n $(ls "$dir" | grep -i Dockerfile) ]]; then
             echo "build ${dir}"
 	    # Must use `buildx` as docker build tool
-            docker build --push -t "$1"/"${dir}":"$2" "$dir"
+            docker build --push -t "$1"/"${dir}":"$2" -f "${dir}/Dockerfile" "."
         fi
     fi
 done

--- a/ts-admin-basic-info-service/Dockerfile
+++ b/ts-admin-basic-info-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-admin-basic-info-service/Dockerfile
+++ b/ts-admin-basic-info-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-admin-basic-info-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-admin-basic-info-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-admin-basic-info-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-admin-basic-info-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18767

--- a/ts-admin-basic-info-service/Dockerfile
+++ b/ts-admin-basic-info-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-admin-basic-info-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-admin-basic-info-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-admin-basic-info-service/Dockerfile.dockerignore
+++ b/ts-admin-basic-info-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-admin-basic-info-service/pom.xml
+!/ts-admin-basic-info-service/src

--- a/ts-admin-order-service/Dockerfile
+++ b/ts-admin-order-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-admin-order-service/Dockerfile
+++ b/ts-admin-order-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-admin-order-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-admin-order-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-admin-order-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-admin-order-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 16112

--- a/ts-admin-order-service/Dockerfile
+++ b/ts-admin-order-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-admin-order-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-admin-order-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-admin-order-service/Dockerfile.dockerignore
+++ b/ts-admin-order-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-admin-order-service/pom.xml
+!/ts-admin-order-service/src

--- a/ts-admin-route-service/Dockerfile
+++ b/ts-admin-route-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-admin-route-service/Dockerfile
+++ b/ts-admin-route-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-admin-route-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-admin-route-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-admin-route-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-admin-route-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 16113

--- a/ts-admin-route-service/Dockerfile
+++ b/ts-admin-route-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-admin-route-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-admin-route-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-admin-route-service/Dockerfile.dockerignore
+++ b/ts-admin-route-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-admin-route-service/pom.xml
+!/ts-admin-route-service/src

--- a/ts-admin-travel-service/Dockerfile
+++ b/ts-admin-travel-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-admin-travel-service/Dockerfile
+++ b/ts-admin-travel-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-admin-travel-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-admin-travel-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-admin-travel-service/Dockerfile
+++ b/ts-admin-travel-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-admin-travel-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-admin-travel-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-admin-travel-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-admin-travel-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 16114

--- a/ts-admin-travel-service/Dockerfile.dockerignore
+++ b/ts-admin-travel-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-admin-travel-service/pom.xml
+!/ts-admin-travel-service/src

--- a/ts-admin-user-service/Dockerfile
+++ b/ts-admin-user-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-admin-user-service/Dockerfile
+++ b/ts-admin-user-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-admin-user-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-admin-user-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-admin-user-service/Dockerfile
+++ b/ts-admin-user-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-admin-user-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-admin-user-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-admin-user-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-admin-user-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 16115

--- a/ts-admin-user-service/Dockerfile.dockerignore
+++ b/ts-admin-user-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-admin-user-service/pom.xml
+!/ts-admin-user-service/src

--- a/ts-assurance-service/Dockerfile
+++ b/ts-assurance-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-assurance-service/Dockerfile
+++ b/ts-assurance-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-assurance-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-assurance-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-assurance-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-assurance-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18888

--- a/ts-assurance-service/Dockerfile
+++ b/ts-assurance-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-assurance-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-assurance-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-assurance-service/Dockerfile.dockerignore
+++ b/ts-assurance-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-assurance-service/pom.xml
+!/ts-assurance-service/src

--- a/ts-auth-service/Dockerfile
+++ b/ts-auth-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-auth-service/Dockerfile
+++ b/ts-auth-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-auth-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-auth-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-auth-service/Dockerfile
+++ b/ts-auth-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-auth-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-auth-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-auth-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-auth-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 12349

--- a/ts-auth-service/Dockerfile.dockerignore
+++ b/ts-auth-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-auth-service/pom.xml
+!/ts-auth-service/src

--- a/ts-avatar-service/Dockerfile
+++ b/ts-avatar-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9.6
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-avatar-service/Dockerfile
+++ b/ts-avatar-service/Dockerfile
@@ -9,7 +9,7 @@ RUN apt install -y libgl1-mesa-glx
 ENV PYTHONUNBUFFERED=TRUE
 
 RUN mkdir -p /app
-ADD . /app/
+ADD ts-avatar-service /app/
 WORKDIR /app
 
 RUN pip install -r requirements.txt

--- a/ts-basic-service/Dockerfile
+++ b/ts-basic-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-basic-service/Dockerfile
+++ b/ts-basic-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-basic-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-basic-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-basic-service/Dockerfile
+++ b/ts-basic-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-basic-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-basic-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-basic-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-basic-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 15680

--- a/ts-basic-service/Dockerfile.dockerignore
+++ b/ts-basic-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-basic-service/pom.xml
+!/ts-basic-service/src

--- a/ts-cancel-service/Dockerfile
+++ b/ts-cancel-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-cancel-service/Dockerfile
+++ b/ts-cancel-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-cancel-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-cancel-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-cancel-service/Dockerfile
+++ b/ts-cancel-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-cancel-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-cancel-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-cancel-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-cancel-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18885

--- a/ts-cancel-service/Dockerfile.dockerignore
+++ b/ts-cancel-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-cancel-service/pom.xml
+!/ts-cancel-service/src

--- a/ts-config-service/Dockerfile
+++ b/ts-config-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-config-service/Dockerfile
+++ b/ts-config-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-config-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-config-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-config-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-config-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 15679

--- a/ts-config-service/Dockerfile
+++ b/ts-config-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-config-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-config-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-config-service/Dockerfile.dockerignore
+++ b/ts-config-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-config-service/pom.xml
+!/ts-config-service/src

--- a/ts-consign-price-service/Dockerfile
+++ b/ts-consign-price-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-consign-price-service/Dockerfile
+++ b/ts-consign-price-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-consign-price-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-consign-price-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-consign-price-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-consign-price-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 16110

--- a/ts-consign-price-service/Dockerfile
+++ b/ts-consign-price-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-consign-price-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-consign-price-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-consign-price-service/Dockerfile.dockerignore
+++ b/ts-consign-price-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-consign-price-service/pom.xml
+!/ts-consign-price-service/src

--- a/ts-consign-service/Dockerfile
+++ b/ts-consign-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-consign-service/Dockerfile
+++ b/ts-consign-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-consign-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-consign-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-consign-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-consign-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 16111

--- a/ts-consign-service/Dockerfile
+++ b/ts-consign-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-consign-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-consign-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-consign-service/Dockerfile.dockerignore
+++ b/ts-consign-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-consign-service/pom.xml
+!/ts-consign-service/src

--- a/ts-contacts-service/Dockerfile
+++ b/ts-contacts-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-contacts-service/Dockerfile
+++ b/ts-contacts-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-contacts-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-contacts-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-contacts-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-contacts-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 12347

--- a/ts-contacts-service/Dockerfile
+++ b/ts-contacts-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-contacts-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-contacts-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-contacts-service/Dockerfile.dockerignore
+++ b/ts-contacts-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-contacts-service/pom.xml
+!/ts-contacts-service/src

--- a/ts-delivery-service/Dockerfile
+++ b/ts-delivery-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-delivery-service/Dockerfile
+++ b/ts-delivery-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-delivery-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-delivery-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-delivery-service/Dockerfile
+++ b/ts-delivery-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-delivery-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-delivery-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-delivery-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-delivery-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18856

--- a/ts-delivery-service/Dockerfile.dockerignore
+++ b/ts-delivery-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-delivery-service/pom.xml
+!/ts-delivery-service/src

--- a/ts-execute-service/Dockerfile
+++ b/ts-execute-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-execute-service/Dockerfile
+++ b/ts-execute-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-execute-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-execute-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-execute-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-execute-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 12386

--- a/ts-execute-service/Dockerfile
+++ b/ts-execute-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-execute-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-execute-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-execute-service/Dockerfile.dockerignore
+++ b/ts-execute-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-execute-service/pom.xml
+!/ts-execute-service/src

--- a/ts-food-delivery-service/Dockerfile
+++ b/ts-food-delivery-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-food-delivery-service/Dockerfile
+++ b/ts-food-delivery-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-food-delivery-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-food-delivery-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-food-delivery-service/Dockerfile
+++ b/ts-food-delivery-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-food-delivery-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-food-delivery-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-food-delivery-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-food-delivery-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18957

--- a/ts-food-delivery-service/Dockerfile.dockerignore
+++ b/ts-food-delivery-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-food-delivery-service/pom.xml
+!/ts-food-delivery-service/src

--- a/ts-food-service/Dockerfile
+++ b/ts-food-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-food-service/Dockerfile
+++ b/ts-food-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-food-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-food-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-food-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-food-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18856

--- a/ts-food-service/Dockerfile
+++ b/ts-food-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-food-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-food-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-food-service/Dockerfile.dockerignore
+++ b/ts-food-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-food-service/pom.xml
+!/ts-food-service/src

--- a/ts-gateway-service/Dockerfile
+++ b/ts-gateway-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-gateway-service/Dockerfile
+++ b/ts-gateway-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-gateway-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-gateway-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-gateway-service-1.0.jar /app/
-CMD ["java", "-Xmx1024m",  "-jar", "/app/ts-gateway-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx1024m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18888 

--- a/ts-gateway-service/Dockerfile
+++ b/ts-gateway-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-gateway-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-gateway-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-gateway-service/Dockerfile.dockerignore
+++ b/ts-gateway-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-gateway-service/pom.xml
+!/ts-gateway-service/src

--- a/ts-inside-payment-service/Dockerfile
+++ b/ts-inside-payment-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-inside-payment-service/Dockerfile
+++ b/ts-inside-payment-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-inside-payment-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-inside-payment-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-inside-payment-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-inside-payment-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18673

--- a/ts-inside-payment-service/Dockerfile
+++ b/ts-inside-payment-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-inside-payment-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-inside-payment-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-inside-payment-service/Dockerfile.dockerignore
+++ b/ts-inside-payment-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-inside-payment-service/pom.xml
+!/ts-inside-payment-service/src

--- a/ts-news-service/Dockerfile
+++ b/ts-news-service/Dockerfile
@@ -4,7 +4,7 @@ FROM mrrm/web.go
 RUN mkdir -p /app
 WORKDIR /app
 
-ADD ./src/main/main.go /app/
+ADD ./ts-news-service/src/main/main.go /app/
 RUN go build
 CMD [ "./app" ]
 

--- a/ts-notification-service/Dockerfile
+++ b/ts-notification-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-notification-service/Dockerfile
+++ b/ts-notification-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-notification-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-notification-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-notification-service/Dockerfile
+++ b/ts-notification-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-notification-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-notification-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-notification-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-notification-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 17853

--- a/ts-notification-service/Dockerfile.dockerignore
+++ b/ts-notification-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-notification-service/pom.xml
+!/ts-notification-service/src

--- a/ts-order-other-service/Dockerfile
+++ b/ts-order-other-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-order-other-service/Dockerfile
+++ b/ts-order-other-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-order-other-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-order-other-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-order-other-service/Dockerfile
+++ b/ts-order-other-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-order-other-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-order-other-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-order-other-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-order-other-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 #CMD java $JAVA_OPTIONS -jar /app/ts-order-other-service-1.0.jar
 EXPOSE 12032

--- a/ts-order-other-service/Dockerfile.dockerignore
+++ b/ts-order-other-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-order-other-service/pom.xml
+!/ts-order-other-service/src

--- a/ts-order-service/Dockerfile
+++ b/ts-order-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-order-service/Dockerfile
+++ b/ts-order-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-order-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-order-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-order-service/Dockerfile
+++ b/ts-order-service/Dockerfile
@@ -1,9 +1,30 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-order-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-order-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-order-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-order-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 #CMD java $JAVA_OPTIONS -jar /app/ts-order-service-1.0.jar
 
 EXPOSE 12031

--- a/ts-order-service/Dockerfile.dockerignore
+++ b/ts-order-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-order-service/pom.xml
+!/ts-order-service/src

--- a/ts-payment-service/Dockerfile
+++ b/ts-payment-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-payment-service/Dockerfile
+++ b/ts-payment-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-payment-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-payment-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-payment-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-payment-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 19001

--- a/ts-payment-service/Dockerfile
+++ b/ts-payment-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-payment-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-payment-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-payment-service/Dockerfile.dockerignore
+++ b/ts-payment-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-payment-service/pom.xml
+!/ts-payment-service/src

--- a/ts-preserve-other-service/Dockerfile
+++ b/ts-preserve-other-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-preserve-other-service/Dockerfile
+++ b/ts-preserve-other-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-preserve-other-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-preserve-other-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-preserve-other-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-preserve-other-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 14569

--- a/ts-preserve-other-service/Dockerfile
+++ b/ts-preserve-other-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-preserve-other-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-preserve-other-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-preserve-other-service/Dockerfile.dockerignore
+++ b/ts-preserve-other-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-preserve-other-service/pom.xml
+!/ts-preserve-other-service/src

--- a/ts-preserve-service/Dockerfile
+++ b/ts-preserve-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-preserve-service/Dockerfile
+++ b/ts-preserve-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-preserve-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-preserve-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-preserve-service/Dockerfile
+++ b/ts-preserve-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-preserve-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-preserve-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-preserve-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-preserve-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 14568

--- a/ts-preserve-service/Dockerfile.dockerignore
+++ b/ts-preserve-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-preserve-service/pom.xml
+!/ts-preserve-service/src

--- a/ts-price-service/Dockerfile
+++ b/ts-price-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-price-service/Dockerfile
+++ b/ts-price-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-price-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-price-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-price-service/Dockerfile
+++ b/ts-price-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-price-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-price-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-price-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-price-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 16579

--- a/ts-price-service/Dockerfile.dockerignore
+++ b/ts-price-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-price-service/pom.xml
+!/ts-price-service/src

--- a/ts-rebook-service/Dockerfile
+++ b/ts-rebook-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-rebook-service/Dockerfile
+++ b/ts-rebook-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-rebook-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-rebook-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-rebook-service/Dockerfile
+++ b/ts-rebook-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-rebook-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-rebook-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-rebook-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-rebook-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18886

--- a/ts-rebook-service/Dockerfile.dockerignore
+++ b/ts-rebook-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-rebook-service/pom.xml
+!/ts-rebook-service/src

--- a/ts-route-plan-service/Dockerfile
+++ b/ts-route-plan-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-route-plan-service/Dockerfile
+++ b/ts-route-plan-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-route-plan-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-route-plan-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-route-plan-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-route-plan-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 14578

--- a/ts-route-plan-service/Dockerfile
+++ b/ts-route-plan-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-route-plan-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-route-plan-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-route-plan-service/Dockerfile.dockerignore
+++ b/ts-route-plan-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-route-plan-service/pom.xml
+!/ts-route-plan-service/src

--- a/ts-route-service/Dockerfile
+++ b/ts-route-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-route-service/Dockerfile
+++ b/ts-route-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-route-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-route-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-route-service/Dockerfile
+++ b/ts-route-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-route-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-route-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-route-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-route-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 11178

--- a/ts-route-service/Dockerfile.dockerignore
+++ b/ts-route-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-route-service/pom.xml
+!/ts-route-service/src

--- a/ts-seat-service/Dockerfile
+++ b/ts-seat-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-seat-service/Dockerfile
+++ b/ts-seat-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-seat-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-seat-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-seat-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-seat-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18898

--- a/ts-seat-service/Dockerfile
+++ b/ts-seat-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-seat-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-seat-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-seat-service/Dockerfile.dockerignore
+++ b/ts-seat-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-seat-service/pom.xml
+!/ts-seat-service/src

--- a/ts-security-service/Dockerfile
+++ b/ts-security-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-security-service/Dockerfile
+++ b/ts-security-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-security-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-security-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-security-service/Dockerfile
+++ b/ts-security-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-security-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-security-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-security-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-security-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 11188

--- a/ts-security-service/Dockerfile.dockerignore
+++ b/ts-security-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-security-service/pom.xml
+!/ts-security-service/src

--- a/ts-station-food-service/Dockerfile
+++ b/ts-station-food-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-station-food-service/Dockerfile
+++ b/ts-station-food-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-station-food-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-station-food-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-station-food-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-station-food-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 18855

--- a/ts-station-food-service/Dockerfile
+++ b/ts-station-food-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-station-food-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-station-food-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-station-food-service/Dockerfile.dockerignore
+++ b/ts-station-food-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-station-food-service/pom.xml
+!/ts-station-food-service/src

--- a/ts-station-service/Dockerfile
+++ b/ts-station-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-station-service/Dockerfile
+++ b/ts-station-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-station-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-station-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-station-service/Dockerfile
+++ b/ts-station-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-station-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-station-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-station-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-station-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 12345

--- a/ts-station-service/Dockerfile.dockerignore
+++ b/ts-station-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-station-service/pom.xml
+!/ts-station-service/src

--- a/ts-ticket-office-service/Dockerfile
+++ b/ts-ticket-office-service/Dockerfile
@@ -5,13 +5,13 @@ RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shang
 RUN mkdir -p /app
 WORKDIR /app
 
-ADD ./node_modules /app/node_modules
-ADD ./package.json /app/
-ADD ./public /app/public
+ADD ./ts-ticket-office-service/node_modules /app/node_modules
+ADD ./ts-ticket-office-service/package.json /app/
+ADD ./ts-ticket-office-service/public /app/public
 # RUN npm install
 
-ADD ./bin /app/bin
-ADD ./app.js /app/
+ADD ./ts-ticket-office-service/bin /app/bin
+ADD ./ts-ticket-office-service/app.js /app/
 CMD [ "npm", "start" ]
 
 EXPOSE 16108

--- a/ts-train-food-service/Dockerfile
+++ b/ts-train-food-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-train-food-service/Dockerfile
+++ b/ts-train-food-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-train-food-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-train-food-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-train-food-service/Dockerfile
+++ b/ts-train-food-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-train-food-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-train-food-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-train-food-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-train-food-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 19999

--- a/ts-train-food-service/Dockerfile.dockerignore
+++ b/ts-train-food-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-train-food-service/pom.xml
+!/ts-train-food-service/src

--- a/ts-train-service/Dockerfile
+++ b/ts-train-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-train-service/Dockerfile
+++ b/ts-train-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-train-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-train-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-train-service/Dockerfile
+++ b/ts-train-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-train-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-train-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-train-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-train-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 14567

--- a/ts-train-service/Dockerfile.dockerignore
+++ b/ts-train-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-train-service/pom.xml
+!/ts-train-service/src

--- a/ts-travel-plan-service/Dockerfile
+++ b/ts-travel-plan-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-travel-plan-service/Dockerfile
+++ b/ts-travel-plan-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-travel-plan-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-travel-plan-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-travel-plan-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-travel-plan-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 14322

--- a/ts-travel-plan-service/Dockerfile
+++ b/ts-travel-plan-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-travel-plan-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-travel-plan-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-travel-plan-service/Dockerfile.dockerignore
+++ b/ts-travel-plan-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-travel-plan-service/pom.xml
+!/ts-travel-plan-service/src

--- a/ts-travel-service/Dockerfile
+++ b/ts-travel-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-travel-service/Dockerfile
+++ b/ts-travel-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-travel-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-travel-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-travel-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-travel-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 12346

--- a/ts-travel-service/Dockerfile
+++ b/ts-travel-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-travel-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-travel-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-travel-service/Dockerfile.dockerignore
+++ b/ts-travel-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-travel-service/pom.xml
+!/ts-travel-service/src

--- a/ts-travel2-service/Dockerfile
+++ b/ts-travel2-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-travel2-service/Dockerfile
+++ b/ts-travel2-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-travel2-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-travel2-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-travel2-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-travel2-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 16346

--- a/ts-travel2-service/Dockerfile
+++ b/ts-travel2-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-travel2-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-travel2-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-travel2-service/Dockerfile.dockerignore
+++ b/ts-travel2-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-travel2-service/pom.xml
+!/ts-travel2-service/src

--- a/ts-ui-dashboard/Dockerfile
+++ b/ts-ui-dashboard/Dockerfile
@@ -2,6 +2,6 @@ FROM openresty/openresty:trusty
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-COPY nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+COPY ts-ui-dashboard/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 
-COPY static /usr/share/nginx/html
+COPY ts-ui-dashboard/static /usr/share/nginx/html

--- a/ts-user-service/Dockerfile
+++ b/ts-user-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-user-service/Dockerfile
+++ b/ts-user-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-user-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-user-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-user-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-user-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 12346

--- a/ts-user-service/Dockerfile
+++ b/ts-user-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-user-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-user-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-user-service/Dockerfile.dockerignore
+++ b/ts-user-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-user-service/pom.xml
+!/ts-user-service/src

--- a/ts-verification-code-service/Dockerfile
+++ b/ts-verification-code-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-verification-code-service/Dockerfile
+++ b/ts-verification-code-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-verification-code-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-verification-code-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-verification-code-service/Dockerfile
+++ b/ts-verification-code-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-verification-code-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-verification-code-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-verification-code-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-verification-code-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 15678

--- a/ts-verification-code-service/Dockerfile.dockerignore
+++ b/ts-verification-code-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-verification-code-service/pom.xml
+!/ts-verification-code-service/src

--- a/ts-voucher-service/Dockerfile
+++ b/ts-voucher-service/Dockerfile
@@ -5,11 +5,11 @@ RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shang
 RUN mkdir -p /app
 WORKDIR /app
 
-COPY requirements.txt ./
+COPY ts-voucher-service/requirements.txt ./
 RUN pip install cryptography
 RUN pip install --no-cache-dir -r requirements.txt
 
-ADD ./server.py /app/
+ADD ./ts-voucher-service/server.py /app/
 CMD [ "python", "server.py" ]
 
 EXPOSE 16101

--- a/ts-wait-order-service/Dockerfile
+++ b/ts-wait-order-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre
+FROM eclipse-temurin:8-jre
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 

--- a/ts-wait-order-service/Dockerfile
+++ b/ts-wait-order-service/Dockerfile
@@ -1,8 +1,29 @@
+From maven:3.9.1-eclipse-temurin-8 as build
+ARG SERVICE_NAME=ts-wait-order-service
+
+WORKDIR /app
+
+COPY pom.xml pom.xml
+COPY ts-common/pom.xml ts-common/pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
+
+# Remove all modules except ts-common and $SERVICE_NAME
+RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
+
+RUN mvn dependency:go-offline -B
+
+COPY ts-common/src ./ts-common/src
+COPY $SERVICE_NAME/src ./$SERVICE_NAME/src
+
+RUN mvn package -DskipTests
+
 FROM eclipse-temurin:8-jre
+ARG SERVICE_NAME=ts-wait-order-service
+ENV SERVICE_NAME=$SERVICE_NAME
 
 RUN /bin/cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && echo 'Asia/Shanghai' >/etc/timezone
 
-ADD ./target/ts-wait-order-service-1.0.jar /app/
-CMD ["java", "-Xmx200m",  "-jar", "/app/ts-wait-order-service-1.0.jar"]
+COPY --from=build /app/$SERVICE_NAME/target/$SERVICE_NAME-1.0.jar /app/
+CMD java -Xmx200m -jar /app/$SERVICE_NAME-1.0.jar
 
 EXPOSE 15678

--- a/ts-wait-order-service/Dockerfile
+++ b/ts-wait-order-service/Dockerfile
@@ -1,16 +1,17 @@
 From maven:3.9.1-eclipse-temurin-8 as build
-ARG SERVICE_NAME=ts-wait-order-service
 
 WORKDIR /app
 
 COPY pom.xml pom.xml
 COPY ts-common/pom.xml ts-common/pom.xml
-COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
-
-# Remove all modules except ts-common and $SERVICE_NAME
-RUN sed -i "/<module>\(ts-common\|$SERVICE_NAME\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
-
+# Remove all modules except ts-common
+RUN sed -i "/<module>\(ts-common\)<\/module>/!{/<module>.*<\/module>/d}" pom.xml
 RUN mvn dependency:go-offline -B
+
+ARG SERVICE_NAME=ts-wait-order-service
+# Add $SERVICE_NAME module
+RUN sed -i "/<module>ts-common<\/module>/a <module>$SERVICE_NAME</module>" pom.xml
+COPY $SERVICE_NAME/pom.xml $SERVICE_NAME/pom.xml
 
 COPY ts-common/src ./ts-common/src
 COPY $SERVICE_NAME/src ./$SERVICE_NAME/src

--- a/ts-wait-order-service/Dockerfile.dockerignore
+++ b/ts-wait-order-service/Dockerfile.dockerignore
@@ -1,0 +1,6 @@
+*
+!/pom.xml
+!/ts-common/pom.xml
+!/ts-common/src
+!/ts-wait-order-service/pom.xml
+!/ts-wait-order-service/src


### PR DESCRIPTION
Prepare 1.0.1 stable release:
- Include hotfixes from https://github.com/FudanSELab/train-ticket/pull/243.
- `make deploy` will deploy from the source code automatically instead of pulling prebuilt images from the docker hub.
- Change java jre docker images, java image is no longer available on docker hub anymore, change to eclipse-temurin versions.
- Fix the avatar service base image, it does not work on the latest `python`, then set it to 3.9.
- Update all deployment versions to 1.0.1.
- Build java images inside docker, avoid the need of having specific `mvn` and `java` versions installed locally.