### PR TITLE
Fix mysql leader is not initialized

### DIFF
--- a/deployment/kubernetes-manifests/quickstart-k8s/charts/mysql/templates/statefulset.yaml
+++ b/deployment/kubernetes-manifests/quickstart-k8s/charts/mysql/templates/statefulset.yaml
@@ -172,12 +172,7 @@ spec:
       - name: xenon
         image: "{{ .Values.xenon.image }}:{{ .Values.xenon.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
-        {{- with .Values.xenon.args }}
-        args:
-        {{- range . }}
-          - {{ . | quote }}
-        {{- end }}
-        {{- end }}
+        command: ['sh', '-c', 'docker-entrypoint;sed -i "s/\"host\": \"localhost\"/\"host\": \"127.0.0.1\"/" /etc/xenon/xenon.json;xenon -c /etc/xenon/xenon.json']
         lifecycle:
           postStart:
             exec:

--- a/deployment/kubernetes-manifests/quickstart-k8s/charts/mysql/values.yaml
+++ b/deployment/kubernetes-manifests/quickstart-k8s/charts/mysql/values.yaml
@@ -79,7 +79,6 @@ mysql:
 xenon:
   image: radondb/xenon
   tag: 1.1.5-helm
-  args: []
 
   ## A string to add extra environment variables
   # extraEnvVars: |

--- a/ts-ui-dashboard/static/assets/js/client_order_list.js
+++ b/ts-ui-dashboard/static/assets/js/client_order_list.js
@@ -121,6 +121,7 @@ var appConsign = new Vue({
                     var info = new Object();
                     info.orderId = that.orderId;
                     info.tripId = that.tripId;
+                    info.userId = sessionStorage.getItem("client_id");
                     var data = JSON.stringify(info);
                     $.ajax({
                         type: "post",


### PR DESCRIPTION
When run `make deploy` none of the mysql servers is promoted to leader. The problem is that if ipv6 is enabled then localhost is reloved to `::1` but the mysql server does not allow the root user access from `::1`.

The solution was just modify the xenon that promotes the mysql server so it connect to `127.0.0.1` instead of `localhost`